### PR TITLE
Remove Let's Encrypt note from force SSL option

### DIFF
--- a/views/expert_settings/website/feeds_force_protocol.php
+++ b/views/expert_settings/website/feeds_force_protocol.php
@@ -2,7 +2,7 @@
 	<?php echo __('How is your website configured and how do you want your feeds to behave?', 'podlove-podcasting-plugin-for-wordpress'); ?>
 </h4>
 <p>
-<?php echo __( 'If you are using a certificate provider not supported by iTunes (like Let\'s Encrypt), you need to select option 3. The Publisher will then force feed URLs as well as enclosure and image URLs within the feed to be http only.', 'podlove-podcasting-plugin-for-wordpress' ) ?></p>
+<?php echo __( 'If you are using a certificate provider not supported by iTunes, you need to select option 3. The Publisher will then force feed URLs as well as enclosure and image URLs within the feed to be http only.', 'podlove-podcasting-plugin-for-wordpress' ) ?></p>
 <h4>
 	<?php echo __('Useful Resources', 'podlove-podcasting-plugin-for-wordpress'); ?>
 </h4>


### PR DESCRIPTION
As iTunes now supports the Let's Encrypt certificates, this note is missleading.